### PR TITLE
use config() instead of env()

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a wrapper for the [ryanwinchester/hubspot-php](https://github.com/ryanwi
 ## Installation
 1. `composer require rossjcooper/laravel-hubspot`
 2. Get a HubSpot API Key from the Intergrations page of your HubSpot account.
-3. `php artisan vendor:publish --provider="Rossjcooper\LaravelHubSpot" --tag="config"` will create a `config/hubspot.php` file.
+3. `php artisan vendor:publish --provider="Rossjcooper\LaravelHubSpot\HubSpotServiceProvider" --tag="config"` will create a `config/hubspot.php` file.
 4. Add your HubSpot API key into the `config/hubspot.php` file.
 5. Add `Rossjcooper\LaravelHubSpot\HubSpotServiceProvider::class` to your providers in your `config/app.php` file.
 6. Add `'HubSpot' => Rossjcooper\LaravelHubSpot\Facades\HubSpot::class` to your aliases in your `config/app.php` file.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This is a wrapper for the [ryanwinchester/hubspot-php](https://github.com/ryanwi
 ## Installation
 1. `composer require rossjcooper/laravel-hubspot`
 2. Get a HubSpot API Key from the Intergrations page of your HubSpot account.
-3. Set a `HUBSPOT_API_KEY` variable in your `.env` file to your HubSpot API Key.
-4. Add `Rossjcooper\LaravelHubSpot\HubSpotServiceProvider::class` to your providers in your `config/app.php` file.
-5. Add `'HubSpot' => Rossjcooper\LaravelHubSpot\Facades\HubSpot::class` to your aliases in your `config/app.php` file.
+3. `php artisan vendor:publish --provider="Rossjcooper\LaravelHubSpot" --tag="config"` will create a `config/hubspot.php` file.
+4. Add your HubSpot API key into the `config/hubspot.php` file.
+5. Add `Rossjcooper\LaravelHubSpot\HubSpotServiceProvider::class` to your providers in your `config/app.php` file.
+6. Add `'HubSpot' => Rossjcooper\LaravelHubSpot\Facades\HubSpot::class` to your aliases in your `config/app.php` file.
 
 ## Usage
 You can use either the facade or inject the HubSpot class as a dependency:

--- a/src/HubSpotServiceProvider.php
+++ b/src/HubSpotServiceProvider.php
@@ -17,7 +17,7 @@ class HubSpotServiceProvider extends ServiceProvider
     {
         //Bind the HubSpot wrapper class
         $this->app->bind('Rossjcooper\LaravelHubSpot\HubSpot', function ($app) {
-            return HubSpot::create(config('hubspot.api_key'));
+            return HubSpot::create(config('hubspot.api_key') || env('HUBSPOT_API_KEY'));
         });
     }
 }

--- a/src/HubSpotServiceProvider.php
+++ b/src/HubSpotServiceProvider.php
@@ -20,4 +20,17 @@ class HubSpotServiceProvider extends ServiceProvider
             return HubSpot::create(config('hubspot.api_key') || env('HUBSPOT_API_KEY'));
         });
     }
+
+    /**
+     * Perform post-registration booting of services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        // config
+        $this->publishes([
+            __DIR__ . '/config/hubspot.php' => config_path('hubspot.php')
+        ], 'config');
+    }
 }

--- a/src/HubSpotServiceProvider.php
+++ b/src/HubSpotServiceProvider.php
@@ -17,7 +17,7 @@ class HubSpotServiceProvider extends ServiceProvider
     {
         //Bind the HubSpot wrapper class
         $this->app->bind('Rossjcooper\LaravelHubSpot\HubSpot', function ($app) {
-            return HubSpot::create(env('HUBSPOT_API_KEY'));
+            return HubSpot::create(config('hubspot.api_key'));
         });
     }
 }

--- a/src/config/hubspot.php
+++ b/src/config/hubspot.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+
+    'api_key' => env('HUBSPOT_API_KEY')
+
+];


### PR DESCRIPTION
For production environment it's recommended to use `php artisan config:cache`. In that case a `bootstrap/cache/config.php` get generated out of all settings in the `config/*.php` files. On app startup If the bootstrap cache file exists `.env` files no longer get parsed.

It's the first time I use `vendor:publish` and understanding how https://github.com/jrean/laravel-user-verification implements it took several attempts.

I left `env('HUBSPOT_API_KEY')` in for backward compatibility since it would be too surprising in a minor update to suddenly require a new configuration file.