### PR TITLE
Updates logic for passing api key to factory

### DIFF
--- a/src/HubSpotServiceProvider.php
+++ b/src/HubSpotServiceProvider.php
@@ -17,7 +17,7 @@ class HubSpotServiceProvider extends ServiceProvider
     {
         //Bind the HubSpot wrapper class
         $this->app->bind('Rossjcooper\LaravelHubSpot\HubSpot', function ($app) {
-            return HubSpot::create(config('hubspot.api_key') ? config('hubspot.api_key') : env('HUBSPOT_API_KEY'));
+            return HubSpot::create(env('HUBSPOT_API_KEY', config('hubspot.api_key')));
         });
     }
 

--- a/src/HubSpotServiceProvider.php
+++ b/src/HubSpotServiceProvider.php
@@ -17,7 +17,7 @@ class HubSpotServiceProvider extends ServiceProvider
     {
         //Bind the HubSpot wrapper class
         $this->app->bind('Rossjcooper\LaravelHubSpot\HubSpot', function ($app) {
-            return HubSpot::create(config('hubspot.api_key') || env('HUBSPOT_API_KEY'));
+            return HubSpot::create(config('hubspot.api_key') ? config('hubspot.api_key') : env('HUBSPOT_API_KEY'));
         });
     }
 


### PR DESCRIPTION
The current logic is passing a boolean/integer into the factory. It was resulting in a HubSpot error: "This hapikey (1) doesn't exist.", even though my config file contained the api_key as a string copied from Hubspot. 

My client is using PHP 5.6 and Laravel 5.2

I've updated the create() call with logic to take the api_key from either the config or env, prioritizing the config.