### PR TITLE
Update README to indicate API KEY goes in .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a wrapper for the [ryanwinchester/hubspot-php](https://github.com/ryanwi
 1. `composer require rossjcooper/laravel-hubspot`
 2. Get a HubSpot API Key from the Intergrations page of your HubSpot account.
 3. `php artisan vendor:publish --provider="Rossjcooper\LaravelHubSpot\HubSpotServiceProvider" --tag="config"` will create a `config/hubspot.php` file.
-4. Add your HubSpot API key into the `config/hubspot.php` file.
+4. Add your HubSpot API key into the your `.env` file: `HUBSPOT_API_KEY=yourApiKey`
 5. Add `Rossjcooper\LaravelHubSpot\HubSpotServiceProvider::class` to your providers in your `config/app.php` file.
 6. Add `'HubSpot' => Rossjcooper\LaravelHubSpot\Facades\HubSpot::class` to your aliases in your `config/app.php` file.
 


### PR DESCRIPTION
- The API key is needed in the .env file, not directly in config/hubspot.php. 
   Updates the documentation to reflect that.