### PR TITLE
Replace ryanwinchester/hubspot-php with hubspot/hubspot-php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
         }
     ],
     "require": {
-        "ryanwinchester/hubspot-php": "~1.0",
-        "illuminate/support": ">=5.3"
+        "illuminate/support": ">=5.3",
+        "hubspot/hubspot-php": "^1.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The libary from ryanwinchester/hubspot-php is abandoned and replaced by a libary provided by HubSpot.

See: https://packagist.org/packages/ryanwinchester/hubspot-php