### PR TITLE
Update HubSpot Composer Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Update HubSpot composer dependency. Allows use of current / future API V3 calls.
+
 ## [2.0.0] - 2020-01-07
 
 - Updated HubSpot base package to official package. [#19]

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "illuminate/support": ">=5.3",
-        "hubspot/hubspot-php": "^1.2"
+        "hubspot/hubspot-php": "^2.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Updating the composer dependency so current / new API calls for v3 can be used. Full list of 2.0.x improvements can be seen here: https://github.com/HubSpot/hubspot-php/blob/master/CHANGELOG.md#203