### PR TITLE
Add support for private app tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ This is a wrapper for the [hubspot/hubspot-php](https://github.com/HubSpot/hubsp
     - Add `Rossjcooper\LaravelHubSpot\HubSpotServiceProvider::class` to your providers array.
     - Add `'HubSpot' => Rossjcooper\LaravelHubSpot\Facades\HubSpot::class` to your aliases array.
 4. `php artisan vendor:publish --provider="Rossjcooper\LaravelHubSpot\HubSpotServiceProvider" --tag="config"` will create a `config/hubspot.php` file.
-5. Add your HubSpot API key into the your `.env` file: `HUBSPOT_API_KEY=yourApiKey`
+5. Add your HubSpot API key or private app access token  into the `.env` file: `HUBSPOT_API_KEY=yourApiKey`
+6. If you use the private app access token, you should alo add `HUBSPOT_USE_OAUTH2=true` to your `.env` file
 
 ## Usage
 You can use either the facade or inject the HubSpot class as a dependency:

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "illuminate/support": ">=5.3",
-        "hubspot/hubspot-php": "^3.0"
+        "hubspot/hubspot-php": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/HubSpotServiceProvider.php
+++ b/src/HubSpotServiceProvider.php
@@ -13,13 +13,13 @@ class HubSpotServiceProvider extends ServiceProvider
 	{
 		//Bind the HubSpot wrapper class
 		$this->app->bind('Rossjcooper\LaravelHubSpot\HubSpot', function ($app) {
-            if (config('hubspot.use_oauth2')) {
-                return HubSpot::createWithOAuth2Token(
-                    config('hubspot.api_key'),
-                    null,
-                    config('hubspot.client_options', [])
-                );
-            }
+			if (env('HUBSPOT_USE_OAUTH2', config('hubspot.use_oauth2'))) {
+				return HubSpot::createWithOAuth2Token(
+					env('HUBSPOT_API_KEY', config('hubspot.api_key')),
+					null,
+					config('hubspot.client_options', [])
+				);
+			}
 
 			return HubSpot::create(
 				env('HUBSPOT_API_KEY', config('hubspot.api_key')),

--- a/src/HubSpotServiceProvider.php
+++ b/src/HubSpotServiceProvider.php
@@ -13,6 +13,14 @@ class HubSpotServiceProvider extends ServiceProvider
 	{
 		//Bind the HubSpot wrapper class
 		$this->app->bind('Rossjcooper\LaravelHubSpot\HubSpot', function ($app) {
+            if (config('hubspot.use_oauth2')) {
+                return HubSpot::createWithOAuth2Token(
+                    config('hubspot.api_key'),
+                    null,
+                    config('hubspot.client_options', [])
+                );
+            }
+
 			return HubSpot::create(
 				env('HUBSPOT_API_KEY', config('hubspot.api_key')),
 				null,

--- a/src/config/hubspot.php
+++ b/src/config/hubspot.php
@@ -1,16 +1,16 @@
 <?php
 
 return [
-    /*
-     * Either the API key or the private app access token
-     */
+	/*
+	 * Either the API key or the private app access token
+	 */
 	'api_key' => env('HUBSPOT_API_KEY'),
 
-    /*
-     * Should the library connect via OAuth2 or use the API key. The usage of the API key will be deprecated on
-     * November 30th, 2022.
-     */
-    'use_oauth2' => env('HUBSPOT_USE_OAUTH2', false),
+	/*
+	 * Should the library connect via OAuth2 or use the API key. The usage of the API key will be deprecated on
+	 * November 30th, 2022.
+	 */
+	'use_oauth2' => env('HUBSPOT_USE_OAUTH2', false),
 
 	'client_options' => [
 		'http_errors' => true,

--- a/src/config/hubspot.php
+++ b/src/config/hubspot.php
@@ -1,7 +1,16 @@
 <?php
 
 return [
+    /*
+     * Either the API key or the private app access token
+     */
 	'api_key' => env('HUBSPOT_API_KEY'),
+
+    /*
+     * Should the library connect via OAuth2 or use the API key. The usage of the API key will be deprecated on
+     * November 30th, 2022.
+     */
+    'use_oauth2' => env('HUBSPOT_USE_OAUTH2', false),
 
 	'client_options' => [
 		'http_errors' => true,

--- a/tests/Unit/ServiceProviderTest.php
+++ b/tests/Unit/ServiceProviderTest.php
@@ -23,13 +23,13 @@ class ServiceProviderTest extends TestCase
 	}
 
     public function test_oauth2_client_is_built()
-    {
-        Config::set('hubspot.use_oauth2', true);
-        Config::set('hubspot.api_key', 'FooBarBaz');
+	{
+		Config::set('hubspot.use_oauth2', true);
+		Config::set('hubspot.api_key', 'FooBarBaz');
 
-        $hubspot = app(HubSpot::class);
+		$hubspot = app(HubSpot::class);
 
-        $this->assertEquals('FooBarBaz', $hubspot->getClient()->key);
-        $this->assertTrue($hubspot->getClient()->oauth2);
-    }
+		$this->assertEquals(env('HUBSPOT_API_KEY'), $hubspot->getClient()->key);
+		$this->assertTrue($hubspot->getClient()->oauth2);
+	}
 }

--- a/tests/Unit/ServiceProviderTest.php
+++ b/tests/Unit/ServiceProviderTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit;
 
+use Illuminate\Support\Facades\Config;
 use Rossjcooper\LaravelHubSpot\HubSpot;
 use Tests\TestCase;
 
@@ -20,4 +21,15 @@ class ServiceProviderTest extends TestCase
 
 		$this->assertEquals(env('HUBSPOT_API_KEY'), $hubspot->getClient()->key);
 	}
+
+    public function test_oauth2_client_is_built()
+    {
+        Config::set('hubspot.use_oauth2', true);
+        Config::set('hubspot.api_key', 'FooBarBaz');
+
+        $hubspot = app(HubSpot::class);
+
+        $this->assertEquals('FooBarBaz', $hubspot->getClient()->key);
+        $this->assertTrue($hubspot->getClient()->oauth2);
+    }
 }


### PR DESCRIPTION
On November 30th, 2022 the usage of the HubSpot API key will be deprecated. See:
https://developers.hubspot.com/changelog/upcoming-api-key-sunset

With this change, the library is modified to allow developers to migrate to the private app tokens by changing a environment value.

This PR resolves issue #33.