### PR TITLE
Add DocBlock to Facade

### DIFF
--- a/src/Facades/HubSpot.php
+++ b/src/Facades/HubSpot.php
@@ -5,6 +5,19 @@ namespace Rossjcooper\LaravelHubSpot\Facades;
 use HubSpot\Discovery\Discovery;
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static \HubSpot\Discovery\Auth\Discovery auth()
+ * @method static \HubSpot\Discovery\Automation\Discovery automation()
+ * @method static \HubSpot\Discovery\Cms\Discovery cms()
+ * @method static \HubSpot\Discovery\Conversations\Discovery conversations()
+ * @method static \HubSpot\Discovery\CommunicationPreferences\Discovery communicationPreferences()
+ * @method static \HubSpot\Discovery\Crm\Discovery crm()
+ * @method static \HubSpot\Discovery\Events\Discovery events()
+ * @method static \HubSpot\Discovery\Files\Discovery files()
+ * @method static \HubSpot\Discovery\Marketing\Discovery marketing()
+ * @method static \HubSpot\Discovery\Settings\Discovery settings()
+ * @method static \HubSpot\Discovery\Webhooks\Discovery webhooks()
+ */
 class HubSpot extends Facade
 {
 	/**


### PR DESCRIPTION
I use [laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper) to provide type hints, but the `HubSpot` facade has no DocBlock.